### PR TITLE
End span after body finishes, rather than when Request is generated.

### DIFF
--- a/akka-http/src/test/scala/com/github/sebruck/opencensus/akka/http/ClientSpec.scala
+++ b/akka-http/src/test/scala/com/github/sebruck/opencensus/akka/http/ClientSpec.scala
@@ -60,7 +60,7 @@ trait ClientSpec
       else
         startedSpan.parentContext shouldBe None
 
-      mockTracing.endedSpansStatuses should contain(Status.OK)
+      mockTracing.spanStatuses should contain(Status.OK)
     }
 
     it should "end a span when the request fails" in {
@@ -71,7 +71,7 @@ trait ClientSpec
                BlankSpan.INSTANCE)(HttpRequest(uri = "/test")).futureValue
       }
 
-      mockTracing.endedSpansStatuses.map(_.getCanonicalCode) should contain(
+      mockTracing.spanStatuses.map(_.getCanonicalCode) should contain(
         Status.INTERNAL.getCanonicalCode)
     }
 

--- a/akka-http/src/test/scala/com/github/sebruck/opencensus/akka/http/TracingDirectiveSpec.scala
+++ b/akka-http/src/test/scala/com/github/sebruck/opencensus/akka/http/TracingDirectiveSpec.scala
@@ -56,7 +56,7 @@ class TracingDirectiveSpec
     val (directive, mockTracing) = directiveWithMock()
 
     Get(path) ~> directive.traceRequest(_ => Directives.complete("")) ~> check {
-      mockTracing.endedSpansStatuses should contain(Status.OK)
+      mockTracing.spanStatuses should contain(Status.OK)
     }
   }
 
@@ -65,7 +65,7 @@ class TracingDirectiveSpec
 
     Get(path) ~> directive.traceRequest(_ =>
       Directives.complete(StatusCodes.InternalServerError)) ~> check {
-      mockTracing.endedSpansStatuses should contain(Status.INTERNAL)
+      mockTracing.spanStatuses should contain(Status.INTERNAL)
     }
   }
 
@@ -74,7 +74,7 @@ class TracingDirectiveSpec
 
     Get(path) ~> directive.traceRequest(_ =>
       throw new Exception("test exception")) ~> check {
-      mockTracing.endedSpansStatuses should contain(Status.INTERNAL)
+      mockTracing.spanStatuses should contain(Status.INTERNAL)
     }
   }
 

--- a/core/src/main/scala/com/github/sebruck/opencensus/Tracing.scala
+++ b/core/src/main/scala/com/github/sebruck/opencensus/Tracing.scala
@@ -41,6 +41,16 @@ trait Tracing {
   def startSpanWithRemoteParent(name: String, parentContext: SpanContext): Span
 
   /**
+    * Sets the status of the span
+    */
+  def setStatus(span: Span, status: Status): Unit
+
+  /**
+    * Ends the span
+    */
+  def endSpan(span: Span): Unit
+
+  /**
     * Ends the span with the given status
     */
   def endSpan(span: Span, status: Status): Unit
@@ -95,6 +105,14 @@ private[opencensus] trait TracingImpl extends Tracing {
   override def startSpanWithRemoteParent(name: String,
                                          parentContext: SpanContext): Span =
     buildSpan(tracer.spanBuilderWithRemoteParent(name, parentContext))
+
+  /** @inheritdoc */
+  def setStatus(span: Span, status: Status): Unit =
+    span.setStatus(status)
+
+  /** @inheritdoc */
+  def endSpan(span: Span): Unit =
+    span.end()
 
   /** @inheritdoc */
   override def endSpan(span: Span, status: Status): Unit =

--- a/http4s/src/test/scala/com/github/sebruck/opencensus/http4s/ServiceRequirementsSpec.scala
+++ b/http4s/src/test/scala/com/github/sebruck/opencensus/http4s/ServiceRequirementsSpec.scala
@@ -56,7 +56,7 @@ trait ServiceRequirementsSpec
       successServiceFromMiddleware(middleware)
         .orNotFound(request)
         .unsafeRunSync()
-      mockTracing.endedSpansStatuses.headOption.value shouldBe Status.OK
+      mockTracing.spanStatuses.headOption.value shouldBe Status.OK
     }
 
     it should "end a span with status INTERNAL when the route fails" in {
@@ -66,7 +66,7 @@ trait ServiceRequirementsSpec
           .orNotFound(request)
           .unsafeRunSync())
 
-      mockTracing.endedSpansStatuses.headOption.value shouldBe Status.INTERNAL
+      mockTracing.spanStatuses.headOption.value shouldBe Status.INTERNAL
     }
 
     it should "end a span with status INTERNAL_ERROR when the route completes with an errornous status code" in {
@@ -76,7 +76,7 @@ trait ServiceRequirementsSpec
         .orNotFound(request)
         .unsafeRunSync()
 
-      mockTracing.endedSpansStatuses.headOption.value shouldBe Status.INTERNAL
+      mockTracing.spanStatuses.headOption.value shouldBe Status.INTERNAL
     }
 
     it should "end a span with status INVALID_ARGUMENT when the route completes with a BadRequest" in {
@@ -86,7 +86,7 @@ trait ServiceRequirementsSpec
         .orNotFound(request)
         .unsafeRunSync()
 
-      mockTracing.endedSpansStatuses.headOption.value shouldBe Status.INVALID_ARGUMENT
+      mockTracing.spanStatuses.headOption.value shouldBe Status.INVALID_ARGUMENT
     }
 
     it should "set the http attributes" in {

--- a/http4s/src/test/scala/com/github/sebruck/opencensus/http4s/TracingClientSpec.scala
+++ b/http4s/src/test/scala/com/github/sebruck/opencensus/http4s/TracingClientSpec.scala
@@ -41,7 +41,7 @@ class TracingClientSpec
 
     clientTracing.trace(expectingClient()).expect[String](path).unsafeRunSync()
     mockTracing.startedSpans.headOption.value.name shouldBe path
-    mockTracing.endedSpansStatuses.headOption.value shouldBe CensusStatus.OK
+    mockTracing.spanStatuses.headOption.value shouldBe CensusStatus.OK
   }
 
   it should "Use the parent span if existing" in {
@@ -99,7 +99,7 @@ class TracingClientSpec
         .expect[String](path)
         .unsafeRunSync())
 
-    mockTracing.endedSpansStatuses.map(_.getCanonicalCode) should contain(
+    mockTracing.spanStatuses.map(_.getCanonicalCode) should contain(
       CensusStatus.INTERNAL.getCanonicalCode)
   }
 


### PR DESCRIPTION
In http4s, there is a difference between the time when the `Response[F]` is generated, and the body is streamed. We should only end the span after the body finishes.

This also sets the status before the span ends, because this information could be useful in "current span" information.

The body should always be consumed, any deviation from this is a bug in http4s.