### PR TITLE
Adhere to spec for status code translation

### DIFF
--- a/akka-http/src/test/scala/com/github/sebruck/opencensus/akka/http/TracingDirectiveSpec.scala
+++ b/akka-http/src/test/scala/com/github/sebruck/opencensus/akka/http/TracingDirectiveSpec.scala
@@ -60,12 +60,12 @@ class TracingDirectiveSpec
     }
   }
 
-  it should "end a span with status INTERNAL_ERROR when the route completes with an errornous status code" in {
+  it should "end a span with status UNKNOWN when the route completes with an errornous status code" in {
     val (directive, mockTracing) = directiveWithMock()
 
     Get(path) ~> directive.traceRequest(_ =>
       Directives.complete(StatusCodes.InternalServerError)) ~> check {
-      mockTracing.endedSpansStatuses should contain(Status.INTERNAL)
+      mockTracing.endedSpansStatuses should contain(Status.UNKNOWN)
     }
   }
 

--- a/http/src/main/scala/com/github/sebruck/opencensus/http/StatusTranslator.scala
+++ b/http/src/main/scala/com/github/sebruck/opencensus/http/StatusTranslator.scala
@@ -5,48 +5,21 @@ import io.opencensus.trace.Status._
 
 object StatusTranslator {
 
+  /**
+    * According to
+    * https://github.com/census-instrumentation/opencensus-specs/blob/master/trace/HTTP.md#status
+    */
   def translate(httpStatus: Int): Status = httpStatus match {
-    case 200 => OK
-    case 400 => INVALID_ARGUMENT
-    case 401 => UNAUTHENTICATED
-    case 403 => PERMISSION_DENIED
-    case 404 => FAILED_PRECONDITION
-    case 405 => INVALID_ARGUMENT
-    case 406 => INVALID_ARGUMENT
-    case 407 => UNAUTHENTICATED
-    case 408 => CANCELLED
-    case 409 => FAILED_PRECONDITION
-    case 410 => FAILED_PRECONDITION
-    case 411 => INVALID_ARGUMENT
-    case 412 => FAILED_PRECONDITION
-    case 413 => INVALID_ARGUMENT
-    case 414 => INVALID_ARGUMENT
-    case 415 => INVALID_ARGUMENT
-    case 416 => OUT_OF_RANGE
-    case 417 => FAILED_PRECONDITION
-    case 420 => RESOURCE_EXHAUSTED
-    case 421 => FAILED_PRECONDITION
-    case 422 => INVALID_ARGUMENT
-    case 423 => PERMISSION_DENIED
-    case 424 => FAILED_PRECONDITION
-    case 428 => FAILED_PRECONDITION
-    case 429 => RESOURCE_EXHAUSTED
-    case 431 => INVALID_ARGUMENT
-    case 449 => UNAVAILABLE
-    case 451 => UNAVAILABLE
-
-    case 500 => INTERNAL
-    case 501 => UNIMPLEMENTED
-    case 502 => UNAVAILABLE
-    case 503 => UNAVAILABLE
-    case 504 => DEADLINE_EXCEEDED
-    case 505 => INVALID_ARGUMENT
-    case 507 => RESOURCE_EXHAUSTED
-    case 509 => RESOURCE_EXHAUSTED
-    case 510 => INVALID_ARGUMENT
-    case 511 => UNAUTHENTICATED
-    case 598 => DEADLINE_EXCEEDED
-    case 599 => DEADLINE_EXCEEDED
-    case _   => UNKNOWN
+    case code if code > 0 && code < 200    => UNKNOWN
+    case code if code >= 200 && code < 400 => OK
+    case 400                               => INVALID_ARGUMENT
+    case 401                               => UNAUTHENTICATED
+    case 403                               => PERMISSION_DENIED
+    case 404                               => NOT_FOUND
+    case 429                               => RESOURCE_EXHAUSTED
+    case 501                               => UNIMPLEMENTED
+    case 503                               => UNAVAILABLE
+    case 504                               => DEADLINE_EXCEEDED
+    case _                                 => UNKNOWN
   }
 }

--- a/http4s/src/test/scala/com/github/sebruck/opencensus/http4s/ServiceRequirementsSpec.scala
+++ b/http4s/src/test/scala/com/github/sebruck/opencensus/http4s/ServiceRequirementsSpec.scala
@@ -69,14 +69,15 @@ trait ServiceRequirementsSpec
       mockTracing.endedSpansStatuses.headOption.value shouldBe Status.INTERNAL
     }
 
-    it should "end a span with status INTERNAL_ERROR when the route completes with an errornous status code" in {
+    it should "end a span with status UNKNOWN when the route completes with an errornous status code" in {
       val (middleware, mockTracing) = middlewareWithMock()
 
       errorServiceFromMiddleware(middleware)
         .orNotFound(request)
         .unsafeRunSync()
+          .status
 
-      mockTracing.endedSpansStatuses.headOption.value shouldBe Status.INTERNAL
+      mockTracing.endedSpansStatuses.headOption.value shouldBe Status.UNKNOWN
     }
 
     it should "end a span with status INVALID_ARGUMENT when the route completes with a BadRequest" in {


### PR DESCRIPTION
As in here https://github.com/census-instrumentation/opencensus-specs/blob/master/trace/HTTP.md#status